### PR TITLE
[hotfix] APIが正しく呼び出されない問題

### DIFF
--- a/yumemi/nuxt.config.ts
+++ b/yumemi/nuxt.config.ts
@@ -4,7 +4,7 @@ export default defineNuxtConfig({
   modules: ['nuxt-highcharts'],
   runtimeConfig: {
     public: {
-      API_KEY: '',
+      apiKey: process.env.API_KEY || '',
     },
   },
 })

--- a/yumemi/utils/resasAPI.ts
+++ b/yumemi/utils/resasAPI.ts
@@ -65,7 +65,7 @@ const fetchPrefectures = async (): Promise<Prefecture[]> => {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        'X-API-KEY': useRuntimeConfig().public.API_KEY,
+        'X-API-KEY': useRuntimeConfig().public.apiKey,
       },
     }
   ).then(async (response) => {
@@ -95,7 +95,7 @@ const fetchPeople = async (
         method: 'GET',
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
-          'X-API-KEY': useRuntimeConfig().public.API_KEY,
+          'X-API-KEY': useRuntimeConfig().public.apiKey,
         },
       }
     ).then(async (response) => {


### PR DESCRIPTION
# 該当Issue
#9 

# 原因
nuxtjsは開発環境時、runtimeConfigで設定した変数に関して自動で環境変数を上書きする機能が存在したため開発時は動作した。
しかし、ビルド後は環境変数を手動で読み込む必要があったため